### PR TITLE
Text Editor Move

### DIFF
--- a/lessons.json
+++ b/lessons.json
@@ -153,7 +153,7 @@
                                 {
                                     "icon": "fa-external-link",
                                     "title": "Why Open Source? - Written by eLearning Staff",
-                                    "href": "https://docs.google.com/document/d/14JHtHVA8zVAzH9Jjo2KhjBlRGhN06AJK3szM64v-6vU/edit?usp=sharing"
+                                    "href": "https://udayton.edu/0/elearning/learn/homepages_gallery.pdf"
                                 },
                                 {
                                     "icon": "fa-external-link",
@@ -383,6 +383,119 @@
                 "warpwire": "xQ8BAA"
             },
             "lessons": [
+                {
+                    "title": "Text Editor",
+                    "anchor": "texteditor",
+                    "icon" : "fa-indent",
+                    "description": "Many useful features are hidden in this magic box.",
+                    "videos" : [
+                        {
+                            "title" : "Isidore 101: Text Editor",
+                            "warpwire" : "pRIBAA"
+                        }
+                    ],
+                    "overviewcontent" : "Use the Announcements tool to post messages for your students. You may attach document and add links. By default, Announcements are also sent to students’ emails, so you can be sure they see the message.",
+                    "section1title" : "Step 1: See It, Learn It",
+                    "section1content" : "Watch this 1 minute video to see how to get started with the Announcements tool.",
+                    "section2title" : "Step 2: Try It",
+                    "section2content" : "It's now time for you to try posting your own Announcement.",
+                    "section2prereq" : "To complete this step, you must first create a test site as instructed in the Creating Course Sites lesson..",
+                    "section2steps" : [
+                        {
+                            "step" : "Log in to Isidore."
+                        },
+                        {
+                            "step" : "Navigate to your testing site."
+                        },
+                        {
+                            "step" : "Post an Announcement."
+                        }
+                    ],
+                    "section3title" : "Step 3: Test your knowledge",
+                    "section3content" : "Now that you've practiced posting an Announcement . . .",
+                     "lti" : [
+                         {
+                             "header": "Quick Quiz",
+                             "description": "Take the three question quiz below to test your Isidore knowledge.",
+                             "icon": "fa-list-ol",
+                             "title": "Text Editor Quiz",
+                             "launch": "mod/learnquiz/index.php?quiz=101_ckeditor",
+                             "resource_link_id": "101_ckeditor"
+                         }
+                     ],
+                    "aside1title" : "Additional Resources",
+                    "aside1content" : [
+                        {
+                            "header" : "Wiki Resources",
+                            "references" : [
+                                {
+                                    "icon" : "fa-external-link",
+                                    "title" : "Full Announcements Tool Help",
+                                    "href" : "https://ewiki.udayton.edu/isidore/Announcements"
+                                }
+                            ]
+                        },
+                        {
+                            "header" : "Related Lessons",
+                            "references" : [
+                                {
+                                    "icon" : "fa-bullhorn",
+                                    "title" : "Course Communication",
+                                    "href" : "#"
+                                },
+                                {
+                                    "icon" : "fa-inbox",
+                                    "title" : "Messages Tool",
+                                    "href" : "#"
+                                }
+                            ]
+                        },
+                        {
+                            "header" : "Additional Articles",
+                            "references" : [
+                                {
+                                    "icon" : "fa-external-link",
+                                    "title" : "When you communicate with students, tone matters",
+                                    "href" : "https://www.chronicle.com/article/When-You-Communicate-With/244756"
+                                },
+                                {
+                                    "icon" : "fa-external-link",
+                                    "title" : "The need for balanced feedback",
+                                    "href" : "https://www.facultyfocus.com/articles/online-education/the-need-for-balanced-feedback/"
+                                }
+                            ]
+                        }
+                    ],
+                    "aside2title" : "Potential Questions You May Have",
+                    "aside2questions" : [
+                        {
+                            "question" : "Where do students see Announcements?",
+                            "answer" : "Students have the option to see Announcements in multiple locations. By default, they can see links to all of their Announcements on their Isidore homepage. They would also see the links to the Announcements on your course site homepage. If you didn’t change the default behavior, students would receive an email notification including the text of the announcement."
+                        },
+                        {
+                            "question" : "Do Announcements work if the site is unpublished?",
+                            "answer" : "Not really. The Announcement will be posted, but an email will not be delivered to students’ inboxes, and they would have no way of seeing the Announcement until the site is published."
+                        },
+                        {
+                            "question" : "Will I receive an email notification about the Announcement as the instructor?",
+                            "answer" : "Yes. Other instructors in your site, if any,  will also receive the email notification."
+                        },
+                        {
+                            "question" : "Can I schedule Announcements?",
+                            "answer" : "You bet! Just choose the 'Specify Dates' option after writing the text for your Announcement. Pick the dates the Announcement should be visible, and it will appear (and disappear) on the selected dates."
+                        },
+                        {
+                            "question" : "Can I save an Announcement as a draft?",
+                            "answer" : "Definitely. Choose the 'Hide' option after writing your Announcement, then press the Post Announcement button. It will be hidden until you edit the Announcement and change that setting to Show."
+                        },
+                        {
+                            "question" : "Can I delete an Announcement?",
+                            "answer" : "Yes - but you cannot delete the email notification from students' inboxes once sent, so proofread before you post!"
+                        }
+                    ],
+                    "aside3title" : "Did you know?",
+                    "aside3content" : "432,000 Announcements have been posted in Isidore since 2008. Y'all do a lot of announcing."
+                },
                  {
                     "title": "Overview",
                     "anchor": "overview",
@@ -1099,119 +1212,6 @@
                              "title": "Calendar Quiz",
                              "launch": "mod/learnquiz/index.php?quiz=101_calendar",
                              "resource_link_id": "101_calendar"
-                         }
-                     ],
-                    "aside1title" : "Additional Resources",
-                    "aside1content" : [
-                        {
-                            "header" : "Wiki Resources",
-                            "references" : [
-                                {
-                                    "icon" : "fa-external-link",
-                                    "title" : "Full Announcements Tool Help",
-                                    "href" : "https://ewiki.udayton.edu/isidore/Announcements"
-                                }
-                            ]
-                        },
-                        {
-                            "header" : "Related Lessons",
-                            "references" : [
-                                {
-                                    "icon" : "fa-bullhorn",
-                                    "title" : "Course Communication",
-                                    "href" : "#"
-                                },
-                                {
-                                    "icon" : "fa-inbox",
-                                    "title" : "Messages Tool",
-                                    "href" : "#"
-                                }
-                            ]
-                        },
-                        {
-                            "header" : "Additional Articles",
-                            "references" : [
-                                {
-                                    "icon" : "fa-external-link",
-                                    "title" : "When you communicate with students, tone matters",
-                                    "href" : "https://www.chronicle.com/article/When-You-Communicate-With/244756"
-                                },
-                                {
-                                    "icon" : "fa-external-link",
-                                    "title" : "The need for balanced feedback",
-                                    "href" : "https://www.facultyfocus.com/articles/online-education/the-need-for-balanced-feedback/"
-                                }
-                            ]
-                        }
-                    ],
-                    "aside2title" : "Potential Questions You May Have",
-                    "aside2questions" : [
-                        {
-                            "question" : "Where do students see Announcements?",
-                            "answer" : "Students have the option to see Announcements in multiple locations. By default, they can see links to all of their Announcements on their Isidore homepage. They would also see the links to the Announcements on your course site homepage. If you didn’t change the default behavior, students would receive an email notification including the text of the announcement."
-                        },
-                        {
-                            "question" : "Do Announcements work if the site is unpublished?",
-                            "answer" : "Not really. The Announcement will be posted, but an email will not be delivered to students’ inboxes, and they would have no way of seeing the Announcement until the site is published."
-                        },
-                        {
-                            "question" : "Will I receive an email notification about the Announcement as the instructor?",
-                            "answer" : "Yes. Other instructors in your site, if any,  will also receive the email notification."
-                        },
-                        {
-                            "question" : "Can I schedule Announcements?",
-                            "answer" : "You bet! Just choose the 'Specify Dates' option after writing the text for your Announcement. Pick the dates the Announcement should be visible, and it will appear (and disappear) on the selected dates."
-                        },
-                        {
-                            "question" : "Can I save an Announcement as a draft?",
-                            "answer" : "Definitely. Choose the 'Hide' option after writing your Announcement, then press the Post Announcement button. It will be hidden until you edit the Announcement and change that setting to Show."
-                        },
-                        {
-                            "question" : "Can I delete an Announcement?",
-                            "answer" : "Yes - but you cannot delete the email notification from students' inboxes once sent, so proofread before you post!"
-                        }
-                    ],
-                    "aside3title" : "Did you know?",
-                    "aside3content" : "432,000 Announcements have been posted in Isidore since 2008. Y'all do a lot of announcing."
-                },
-                 {
-                    "title": "Text Editor",
-                    "anchor": "texteditor",
-                    "icon" : "fa-indent",
-                    "description": "Many useful features are hidden in this magic box.",
-                    "videos" : [
-                        {
-                            "title" : "Isidore 101: Text Editor",
-                            "warpwire" : "pRIBAA"
-                        }
-                    ],
-                    "overviewcontent" : "Use the Announcements tool to post messages for your students. You may attach document and add links. By default, Announcements are also sent to students’ emails, so you can be sure they see the message.",
-                    "section1title" : "Step 1: See It, Learn It",
-                    "section1content" : "Watch this 1 minute video to see how to get started with the Announcements tool.",
-                    "section2title" : "Step 2: Try It",
-                    "section2content" : "It's now time for you to try posting your own Announcement.",
-                    "section2prereq" : "To complete this step, you must first create a test site as instructed in the Creating Course Sites lesson..",
-                    "section2steps" : [
-                        {
-                            "step" : "Log in to Isidore."
-                        },
-                        {
-                            "step" : "Navigate to your testing site."
-                        },
-                        {
-                            "step" : "Post an Announcement."
-                        }
-                    ],
-                    "section3title" : "Step 3: Test your knowledge",
-                    "section3content" : "Now that you've practiced posting an Announcement . . .",
-                     "lti" : [
-                         {
-                             "header": "Quick Quiz",
-                             "description": "Take the three question quiz below to test your Isidore knowledge.",
-                             "icon": "fa-list-ol",
-                             "title": "Text Editor Quiz",
-                             "launch": "mod/learnquiz/index.php?quiz=101_ckeditor",
-                             "resource_link_id": "101_ckeditor"
                          }
                      ],
                     "aside1title" : "Additional Resources",


### PR DESCRIPTION
I moved the Text Editor Lesson to the top of Isidore 101. I swapped out the link to Why Open Source. 